### PR TITLE
fix(2024 rewrite): layout shift 

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -1,30 +1,3 @@
-.main-animation {
-  animation: page-animation 1s forwards;
-}
-
-@keyframes page-animation {
-  0% {
-    opacity: 0;
-  }
-  100% {
-    opacity: 1;
-  }
-}
-
-.landing-animation {
-  animation: landing-page-animation 800ms forwards;
-}
-
-@keyframes landing-page-animation {
-  0% {
-    opacity: 0;
-    transform: translateY(-10px);
-  }
-  100% {
-    opacity: 1;
-  }
-}
-
 th {
   padding: 1rem;
   text-align: left;

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,8 +1,10 @@
 const Footer = () => {
   return (
-    <footer className="flex flex-col items-center gap-2 px-5 py-3 text-sm text-slate-500 dark:text-slate-400">
-      <p>Designed and build by Niko Söder.</p>
-      <div className="flex flex-col">
+    <footer className="flex flex-col items-center gap-5 px-5 py-3 text-sm text-slate-500 dark:text-slate-400">
+      <p className="italic text-slate-600 dark:text-slate-300">
+        Designed and build by Niko Söder.
+      </p>
+      <div className="flex flex-col gap-4">
         <a href="https://github.com/NikoSoder/solita-front" target="_blank">
           Github
         </a>

--- a/src/components/Home.tsx
+++ b/src/components/Home.tsx
@@ -1,7 +1,7 @@
 import { useState } from "react";
 import Station from "./Station";
 import apiService from "../services/api-service";
-import { Loading } from "./Loading";
+import { LoadingSkeleton } from "./Loading";
 import PopularStations from "./PopularStations";
 import Map from "./Map";
 import { Trips } from "./Trips";
@@ -20,7 +20,11 @@ const Home = () => {
 
   function checkSelectedStationStatus() {
     if (isPending) {
-      return <Loading />;
+      return (
+        <div className="flex-1 grow">
+          <LoadingSkeleton height="231" />;
+        </div>
+      );
     }
     if (isError) {
       return <div className="text-center">Error: {error.message}</div>;

--- a/src/components/Home.tsx
+++ b/src/components/Home.tsx
@@ -38,7 +38,16 @@ const Home = () => {
   return (
     <div className="container mx-auto flex flex-col gap-6 p-3 pb-10 pt-20 lg:flex-row">
       {/* trips view table */}
-      <Trips />
+      <div className="flex flex-col gap-4 lg:w-2/3">
+        <Trips />
+        {isPending ? (
+          <LoadingSkeleton height="327" />
+        ) : isError ? (
+          <div className="text-center">Error: {error.message}</div>
+        ) : (
+          <Map selected={data.station} />
+        )}
+      </div>
       {/* stations view */}
       <div className="flex grow flex-col gap-4">
         <div>
@@ -50,13 +59,6 @@ const Home = () => {
           <StationList handleStationClick={handleStationClick} />
           {checkSelectedStationStatus()}
         </div>
-        {isPending ? (
-          <Loading />
-        ) : isError ? (
-          <div className="text-center">Error: {error.message}</div>
-        ) : (
-          <Map selected={data.station} />
-        )}
         <PopularStations handleStationClick={handleStationClick} />
       </div>
     </div>

--- a/src/components/LandingPage.tsx
+++ b/src/components/LandingPage.tsx
@@ -2,8 +2,9 @@ import { Link } from "react-router-dom";
 import siteDark from "../assets/site-dark.png";
 import siteLight from "../assets/site-light.png";
 const LandingPage = () => {
+  const isDarkTheme = document.documentElement.classList.contains("dark");
   return (
-    <div className="landing-animation container mx-auto flex flex-col gap-10 px-3 py-10">
+    <div className="container mx-auto flex flex-col gap-10 px-3 py-10">
       <div className="text-center">
         <h1 className="mb-1 text-5xl font-bold tracking-wide text-blue-900 dark:text-blue-200">
           Helsinki city bike
@@ -32,21 +33,11 @@ const LandingPage = () => {
         </Link>
       </div>
       <div className="flex justify-center">
-        <div className="max-w-2xl">
-          {document.documentElement.classList.contains("dark") ? (
-            <img
-              className="w-full skew-y-6"
-              src={siteDark}
-              alt="Site picture"
-            />
-          ) : (
-            <img
-              className="w-full skew-y-6"
-              src={siteLight}
-              alt="Site picture"
-            />
-          )}
-        </div>
+        <img
+          className="aspect-[56/41] w-full max-w-2xl skew-y-6"
+          src={isDarkTheme ? siteDark : siteLight}
+          alt="Site picture"
+        />
       </div>
     </div>
   );

--- a/src/components/Loading.tsx
+++ b/src/components/Loading.tsx
@@ -14,3 +14,14 @@ export const LoadingSmall = () => {
     </div>
   );
 };
+
+export const LoadingSkeleton = ({ height }: { height: string }) => {
+  return (
+    <div
+      className="mx-auto w-full rounded-md"
+      style={{ height: `${height}px` }}
+    >
+      <div className="h-full animate-pulse rounded-lg bg-slate-100 p-4 dark:bg-slate-700"></div>
+    </div>
+  );
+};

--- a/src/components/PopularStations.tsx
+++ b/src/components/PopularStations.tsx
@@ -1,6 +1,6 @@
 import { useQuery } from "@tanstack/react-query";
 import apiService from "../services/api-service";
-import { Loading } from "./Loading";
+import { LoadingSkeleton } from "./Loading";
 
 type ChildPropsPopularStations = {
   handleStationClick: (stationId: string) => void;
@@ -13,7 +13,7 @@ const PopularStations = ({ handleStationClick }: ChildPropsPopularStations) => {
   });
 
   if (isPending) {
-    return <Loading />;
+    return <LoadingSkeleton height="401" />;
   }
 
   if (isError) {

--- a/src/components/Station.tsx
+++ b/src/components/Station.tsx
@@ -10,7 +10,7 @@ type ChildPropsStation = {
 
 const Station = ({ station, isFetching }: ChildPropsStation) => {
   return (
-    <div className="min-h-[231px] max-w-sm flex-1 rounded border border-transparent bg-white p-6 text-slate-600 shadow-md dark:border dark:border-slate-500 dark:bg-slate-800 dark:text-slate-300">
+    <div className="flex-1 rounded border border-transparent bg-white p-6 text-slate-600 shadow-md dark:border dark:border-slate-500 dark:bg-slate-800 dark:text-slate-300">
       <div className="mb-6 flex items-center justify-between border-b dark:border-slate-700">
         <h2 className="text-lg text-slate-900 dark:text-slate-200">
           {station.station.osoite}

--- a/src/components/StationList.tsx
+++ b/src/components/StationList.tsx
@@ -1,7 +1,7 @@
 import { useInfiniteQuery } from "@tanstack/react-query";
 import apiService from "../services/api-service";
 import React from "react";
-import { Loading } from "./Loading";
+import { LoadingSkeleton } from "./Loading";
 
 interface ChildPropsStationList {
   handleStationClick: (stationId: string) => void;
@@ -31,7 +31,11 @@ const StationList = ({ handleStationClick }: ChildPropsStationList) => {
   });
 
   if (isPending) {
-    return <Loading />;
+    return (
+      <div className="flex-1 grow">
+        <LoadingSkeleton height="288" />;
+      </div>
+    );
   }
 
   if (error) {
@@ -40,7 +44,7 @@ const StationList = ({ handleStationClick }: ChildPropsStationList) => {
 
   return (
     <div className="flex-1 grow">
-      <div className="flex max-h-72 max-w-sm grow flex-col overflow-y-auto rounded bg-white shadow-md dark:border dark:border-slate-500 dark:bg-slate-800">
+      <div className="flex max-h-72 grow flex-col overflow-y-auto rounded bg-white shadow-md dark:border dark:border-slate-500 dark:bg-slate-800">
         <ul className="flex flex-col text-slate-700 dark:text-slate-300">
           {data.pages.map((group, i) => (
             <React.Fragment key={i}>

--- a/src/components/Trips.tsx
+++ b/src/components/Trips.tsx
@@ -3,7 +3,7 @@ import { useState } from "react";
 import apiService from "../services/api-service";
 import Table from "./Table";
 import Pagination from "./Pagination";
-import { Loading } from "./Loading";
+import { LoadingSkeleton } from "./Loading";
 
 export function Trips() {
   const [page, setPage] = useState(0);
@@ -17,7 +17,7 @@ export function Trips() {
 
   function checkTripPageStatus() {
     if (isPending) {
-      return <Loading />;
+      return <LoadingSkeleton height="700" />;
     }
     if (isError) {
       return <div className="text-center">Error: {error.message}</div>;
@@ -26,7 +26,7 @@ export function Trips() {
   }
 
   return (
-    <div className="drop-shadow-lg dark:text-slate-100 lg:w-2/3">
+    <div className="drop-shadow-lg dark:text-slate-100">
       {/* pagination */}
       <div
         className="relative flex flex-col gap-2 rounded-t-lg bg-white p-4


### PR DESCRIPTION
- Add loading skeleton to prevent layout shift
- Add aspect ratio class to landing page image to prevent layout shift
- More spacing to footer
- Move map below trips table